### PR TITLE
speed up spheres masker inverse transform

### DIFF
--- a/nilearn/input_data/tests/test_nifti_spheres_masker.py
+++ b/nilearn/input_data/tests/test_nifti_spheres_masker.py
@@ -124,7 +124,7 @@ def test_small_radius():
 
     masker = NiftiSpheresMasker([seed], radius=0.1,
                                 mask_img=nibabel.Nifti1Image(mask, affine))
-    with pytest.raises(ValueError, match='Sphere around seed #0 is empty'):
+    with pytest.raises(ValueError, match='These spheres are empty'):
         masker.fit_transform(nibabel.Nifti1Image(data, affine))
 
     masker = NiftiSpheresMasker([seed], radius=1.6,
@@ -283,7 +283,7 @@ def test_small_radius_inverse():
                                 mask_img=nibabel.Nifti1Image(mask, affine))
     masker.fit(nibabel.Nifti1Image(data, affine))
 
-    with pytest.raises(ValueError, match='Sphere around seed #0 is empty'):
+    with pytest.raises(ValueError, match='These spheres are empty'):
         masker.inverse_transform(spheres_data)
 
     masker = NiftiSpheresMasker([seed], radius=1.6,


### PR DESCRIPTION
this saves a bit of computation and memory in the inverse transform by

- using only voxels inside the mask
- using the adjacency matrix returned by `_apply_mask_and_get_affinity` directly
  rather than iterating over rows and building a new matrix